### PR TITLE
Add a java language standard

### DIFF
--- a/standards/java.md
+++ b/standards/java.md
@@ -4,22 +4,7 @@ category: Code Standards
 # Java Language Conventions
 
 ## Code style
-Teams should adopt a consistent coding style, and use tooling to automatically check
-that it is being followed.
-
-We recommend following the [Google Style Guide](https://google.github.io/styleguide/javaguide.html).
-This has formatters which can be imported into [IntelliJ](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml) or [Eclipse](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml).
-
-Having a chosen style is more important than having the perfect style, since house styles need maintaining and can encourage [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
-
-You should also run a static analysis tool as part of your CI build - this will let the committer know straight away if their IDE is not set up correctly or they have checked in something without the IDE autoformatting it. This allows the reviewer of the PR to focus on the actual changes. Static analysis tools for Java include [SonarQube](https://www.sonarqube.org/), [Codacy](https://www.codacy.com/), [FindBugs](http://findbugs.sourceforge.net/) and [CheckStyle](http://checkstyle.sourceforge.net/).
-
-### Introducing a code style to existing projects
-Introducing a new coding convention to an existing project will flag up a lot of violations.
-
-It's simplest to fix these in one go, when there are not many other branches being worked on.
-
-`git rebase -Xignore-space-change master` is a helpful command for resolving conflicts with branches if the whitespace conventions have changed.
+Teams should follow a consistent coding style, and enforce it with a linting tool. See [Linting Rules - Java Projects](/standards/linting-rules/#java-projects).
 
 ## JDK
 New versions of OpenJDK are released on a 6 monthly cycle. You should choose an up to date JDK and continue updating your JDK to keep pace with new releases. Not updating makes it harder to update in the future.

--- a/standards/linting-rules.md
+++ b/standards/linting-rules.md
@@ -4,12 +4,40 @@ category: Code Standards
 # Linting rules
 
 All projects should be checked against the published linting rules to ensure a consistent developer experience across projects. Both locally during
-development and as part of the build, builds should be failed if the linting checks fail.
+development and as part of the build, builds should be failed if the linting checks fail. This lets the committer know if their editor is not set up correctly or they have checked in something without the editor autoformatting it, and [encourages reviewers to give more useful feedback](https://technology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/) instead of nitpicking style errors.
+
+Having a chosen style is more important than having the perfect style, since house styles need maintaining and can encourage [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
+
 
 ## Java Projects
+We recommend following the [Google Style Guide](https://google.github.io/styleguide/javaguide.html).
+This has formatters which can be imported into [IntelliJ](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml) or [Eclipse](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml).
 
-Should be checked as part of the build using [checkstyle](https://github.com/checkstyle/checkstyle) this can also be run locally using [this configuration file](https://github.com/ministryofjustice/digital-probation-standards/resources/checkstyle.xml) which is the Java sun checkstyle rule with slight alterations around Javadoc checks, hidden fields and line length.
-The [configuration file](https://github.com/ministryofjustice/digital-probation-standards/resources/checkstyle.xml) can also be imported into IntelliJ, eclipse and netbeans using their CheckStyle plugins, which will show any warnings and format automatically.
+For linting builds, you can use [CheckStyle](https://github.com/checkstyle/checkstyle), which can also be run locally before committing changes. Other static analysis tools for Java include [SonarQube](https://www.sonarqube.org/), [Codacy](https://www.codacy.com/) and [FindBugs](http://findbugs.sourceforge.net/).
+
+To configure checkstyle in Gradle, add the following to your build.gradle:
+
+```groovy
+plugins {
+    id 'checkstyle'
+}
+```
+
+Then add your chosen configuration to `config/checkstyle/checkstyle.xml`:
+
+- [Google style config](https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml)
+- [Modified Sun style config](https://github.com/ministryofjustice/development-standards-alpha/blob/master/resources/checkstyle.xml)
+
+The latter is the Java sun checkstyle rule with slight alterations around Javadoc checks, hidden fields and line length.
+
+Checkstyle configurations can also be imported into IntelliJ, eclipse and netbeans using their CheckStyle plugins, which will show any warnings and format automatically.
 
 ## Javascript Projects
 Should be checked as part of the build using [ESLint](https://eslint.org) which is available as node module, the Airbnb style is used and this module [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base) should be used on all projects. A coding style for the IntelliJ IDE is available [here](https://github.com/ministryofjustice/digital-probation-standards/resources/Webstorm-Airbnb-Javascript-codeStyle.xml)
+
+## Introducing a code style to existing projects
+Introducing a new coding convention to an existing project will flag up a lot of violations.
+
+It's simplest to fix these in one go, when there are not many other branches being worked on.
+
+`git rebase -Xignore-space-change master` is a helpful command for resolving conflicts with branches if the whitespace conventions have changed.


### PR DESCRIPTION
This is a first stab at putting together some common guidance for java teams at the MOJ.

It's heavily based on the [GDS way guidance](https://gds-way.cloudapps.digital/manuals/programming-languages/java.html#java-style-guide).

We've made the following changes:

- Promote Google Style Guide as the default format instead of Intellij
defaults. I don't think Intellij is a good fit for MOJ because you can't
easily apply the same conventions to other IDEs/static analysis tools.
We can potentially expand on this to suggest other alternatives, but I
think this is a decent starting point and this was the main
recommendation I got when I first asked around about coding standards on
slack.

- Take out the section about dependency injection and web frameworks -
this is better suited to the tech menu and MOJ use the spring ecosystem
whereas GDS don't

- Take out the section about imports, this should be covered by the
google style guide

- Take out the section about testing, as we have another page for that

- Slightly rewrite the section about the JDK. I think this is quite
confusing and I want to explicitly recommend going with the latest JDK
version unless there's a good reason not to.

