### PR TITLE
Update feature branch guidance

### DIFF
--- a/standards/branching-strategies.md
+++ b/standards/branching-strategies.md
@@ -47,16 +47,32 @@ One of the main issues with branching strategies is that it can prevent code bei
 - Extensive code reviews can be laborious
 - Significant new features can be complicated to role out
 - A merged feature that is in testing could prevent things like hotfixes being applied to production
-- Marge conflicts
+- Merge conflicts
 
-## Mitigating the problems with feature branching 
+## Mitigating the problems with feature branching
 
-Using in-code strategies such as **feature toggles** and **UI last** can help mitigate some of the problems with feature branching.
+Using in-code strategies such as **feature toggles**, **UI last**, **splitting features into multiple deployments** and **reversible deployments** can help mitigate some of the problems with feature branching.
 
 ### Feature toggles
 
-Using in code configuration to turn features on and off 
+Using in code configuration to turn features on and off
+
+### Splitting features into multiple deployments
+Where possible, deploy things in multiple stages so that if stuff breaks you can quickly identify the problem and fix it.
+
+This way you can integrate stuff into the master branch quicker and get feedback on your work earlier.
+
+If a branch becomes difficult to review because of a large number of commits, consider whether any of that work can be deployed in isolation. If so, then you can [cherry-pick](https://git-scm.com/docs/git-cherry-pick) changes into new, smaller feature branches.
 
 ### UI last
+With significant changes to API endpoints, you could create a new endpoint instead of editing the existing one; same could be applied to a UI change where you could copy a page, make your changes and tie it all together at the end when you're ready to release the change to users.
 
-With significant changes to API endpoints, you could create a new endpoint instead of editing the existing one; same could be applied to a UI change where you could copy a page, make your changes and tie it all together at the end when you're ready to deploy.
+### Make deployments reversable
+You should be able to safely rollback any deployment.
+
+This can be tricky when data is involved. For example, if you drop a column in your database as part of a larger code change, then the previous version of the code won't work properly, so your deploy will require downtime, and you won't be able to roll back if the build doesn't work.
+
+The safest way to make these kind of changes is in stages, e.g.
+- https://www.brunton-spall.co.uk/post/2014/05/06/database-migrations-done-right/
+- https://stripe.com/gb/blog/online-migrations
+- https://samsaffron.com/archive/2018/03/22/managing-db-schema-changes-without-downtime


### PR DESCRIPTION
This expands on the feature branch guidance. 

All of this stuff is very useful and relevant to my team, as we have recently parked a major piece of redesign work, which was on a feature branch for a long time but none of it made it into production 😞

We noticed the initial part overlaps with the [using git guide](https://ministryofjustice.github.io/technical-guidance/guides/using-git) in the existing tech standards.

I think that one is a bit too broad in scope, so I've lifted the bits that related to feature branches (naming conventions, committing regularly, pushing regularly). If this is ok, we'll just need to remove these sections from the git guide if/when merging this back upstream.

I've added a couple of suggestions to the `Mitigating the problems with feature branching` bit:
- Deploying stuff in stages
- Making deployments reversible

I didn't entirely understand the `UI last` section so I've left that as is.

For each of these strategies I think it would be helpful to link to article/blog posts that explain them in more detail. So far I've only done this for the reversible deployment one as I already had some notes on that.

I didn't get around to writing anything about this but multivariate testing (or A/B testing) is probably worth mentioning here too. It's similar to feature toggles but you are measuring something before switching something on. If teams within MOJ are already doing this it would be really good to highlight.